### PR TITLE
Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+pykqml.egg-info
+__pycache__/

--- a/README.rst
+++ b/README.rst
@@ -45,3 +45,8 @@ You can create a new KQML messaging agent as
             # ...
             self.reply(msg, reply_msg)
 
+You can run the tests with the following command:
+
+.. code:: python
+
+   python -m unittest discover tests

--- a/kqml/__init__.py
+++ b/kqml/__init__.py
@@ -1,19 +1,18 @@
+from __future__ import absolute_import
+
 __version__ = '0.5'
 import logging
 
-class KQMLObject(object):
-    """This is the parent class for KQML classes representing messages."""
-    pass
-
-from kqml_exceptions import *
-from kqml_quotation import KQMLQuotation
-from kqml_token import KQMLToken
-from kqml_string import KQMLString
-from kqml_list import KQMLList
-from kqml_performative import KQMLPerformative
-from kqml_reader import KQMLReader
-from kqml_dispatcher import KQMLDispatcher
-from kqml_module import KQMLModule
+from .common import *
+from .kqml_exceptions import *
+from .kqml_quotation import KQMLQuotation
+from .kqml_token import KQMLToken
+from .kqml_string import KQMLString
+from .kqml_list import KQMLList
+from .kqml_performative import KQMLPerformative
+from .kqml_reader import KQMLReader
+from .kqml_dispatcher import KQMLDispatcher
+from .kqml_module import KQMLModule
 
 logging.basicConfig(format='%(levelname)s: %(name)s - %(message)s',
                     level=logging.INFO)

--- a/kqml/common.py
+++ b/kqml/common.py
@@ -1,0 +1,3 @@
+class KQMLObject(object):
+    """This is the parent class for KQML classes representing messages."""
+    pass

--- a/kqml/kqml_list.py
+++ b/kqml/kqml_list.py
@@ -1,8 +1,9 @@
-import StringIO
-from kqml import KQMLObject
-from kqml_token import KQMLToken
-from kqml_string import KQMLString
-import kqml_reader
+from six import BytesIO, StringIO
+from six import string_types
+from .common import KQMLObject
+from .kqml_token import KQMLToken
+from .kqml_string import KQMLString
+from . import kqml_reader
 
 class KQMLList(KQMLObject):
     def __init__(self, objects=None):
@@ -15,7 +16,7 @@ class KQMLList(KQMLObject):
             for o in objects:
                 self.append(o)
         # If a string is passed, it becomes the "head" of the list
-        elif isinstance(objects, basestring):
+        elif isinstance(objects, string_types):
             self.append(objects)
 
     def __str__(self):
@@ -104,7 +105,7 @@ class KQMLList(KQMLObject):
             If a string is passed, it is instantiated as a
             KQMLToken before being added to the list.
         """
-        if isinstance(obj, basestring):
+        if isinstance(obj, string_types):
             obj = KQMLToken(obj)
         self.data.append(obj)
 
@@ -117,7 +118,7 @@ class KQMLList(KQMLObject):
             If a string is passed, it is instantiated as a
             KQMLToken before being added to the list.
         """
-        if isinstance(obj, basestring):
+        if isinstance(obj, string_types):
             obj = KQMLToken(obj)
         self.data.insert(0, obj)
 
@@ -164,9 +165,9 @@ class KQMLList(KQMLObject):
         """
         if not keyword.startswith(':'):
             keyword = ':' + keyword
-        if isinstance(value, basestring):
+        if isinstance(value, string_types):
             value = KQMLToken(value)
-        if isinstance(keyword, basestring):
+        if isinstance(keyword, string_types):
             keyword = KQMLToken(keyword)
         found = False
         for i, key in enumerate(self.data):
@@ -197,7 +198,7 @@ class KQMLList(KQMLObject):
             kl = KQMLList.from_string('(FAILURE)')
             kl.sets('reason', 'this is a custom string message, not a token')
         """
-        if isinstance(value, basestring):
+        if isinstance(value, string_types):
             value = KQMLString(value)
         self.set(keyword, value)
 
@@ -206,13 +207,13 @@ class KQMLList(KQMLObject):
         out.write(full_str)
 
     def to_string(self):
-        out = StringIO.StringIO()
+        out = StringIO()
         self.write(out)
         return out.getvalue()
 
     @classmethod
     def from_string(cls, s):
-        sreader = StringIO.StringIO(s)
+        sreader = BytesIO(bytes(s.encode("utf-8")))
         kreader = kqml_reader.KQMLReader(sreader)
         return kreader.read_list()
 
@@ -222,7 +223,7 @@ class KQMLList(KQMLObject):
         return KQMLList(self.data[from_idx:to_idx])
 
     def index_of(self, obj):
-        if isinstance(obj, basestring):
+        if isinstance(obj, string_types):
             return self.index_of_string(obj)
         else:
             try:
@@ -243,4 +244,3 @@ class KQMLList(KQMLObject):
             return idx
         except ValueError:
             return -1
-

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -2,9 +2,11 @@ import io
 import sys
 import socket
 import logging
-from kqml import KQMLReader, KQMLDispatcher
-from kqml import KQMLList, KQMLPerformative
-from kqml_exceptions import KQMLException
+from .kqml_list import KQMLList
+from .kqml_performative import KQMLPerformative
+from .kqml_reader import KQMLReader
+from .kqml_dispatcher import KQMLDispatcher
+from .kqml_exceptions import KQMLException
 
 logger = logging.getLogger('KQMLModule')
 

--- a/kqml/kqml_performative.py
+++ b/kqml/kqml_performative.py
@@ -1,16 +1,16 @@
-import StringIO
-from kqml import KQMLObject
-import kqml_reader
-import kqml_list
-from kqml_token import KQMLToken
-from kqml_exceptions import KQMLBadPerformativeException
+from six import BytesIO, string_types
+from .common import KQMLObject
+from . import kqml_reader
+from . import kqml_list
+from .kqml_token import KQMLToken
+from .kqml_exceptions import KQMLBadPerformativeException
 
 class KQMLPerformative(KQMLObject):
     def __init__(self, objects):
         if not objects:
             raise KQMLBadPerformativeException('no elements for initialization')
         # If we get a string then we start a list with the string as the head
-        if isinstance(objects, basestring):
+        if isinstance(objects, string_types):
             self.data = kqml_list.KQMLList(objects)
         elif isinstance(objects, kqml_list.KQMLList):
             self._validate(objects)
@@ -62,7 +62,7 @@ class KQMLPerformative(KQMLObject):
 
     @classmethod
     def from_string(cls, s):
-        sreader = StringIO.StringIO(s)
+        sreader = BytesIO(s)
         kreader = kqml_reader.KQMLReader(sreader)
         return cls(kreader.read_list())
 

--- a/kqml/kqml_quotation.py
+++ b/kqml/kqml_quotation.py
@@ -1,4 +1,4 @@
-import StringIO
+from six import StringIO
 from kqml import KQMLObject
 
 class KQMLQuotation(KQMLObject):
@@ -16,7 +16,8 @@ class KQMLQuotation(KQMLObject):
         out.write(self.quote_type)
         self.kqml_object.write(out)
 
+    # FIXME: Needs tests
     def to_string(self):
-        out = StringIO.StringIO()
+        out = StringIO()
         self.write(out)
         return out.getvalue()

--- a/kqml/kqml_reader.py
+++ b/kqml/kqml_reader.py
@@ -1,12 +1,12 @@
 import io
 import logging
-from kqml_exceptions import *
+from .kqml_exceptions import *
 
-import kqml_list
-import kqml_performative
-from kqml_token import KQMLToken
-from kqml_string import KQMLString
-from kqml_quotation import KQMLQuotation
+from . import kqml_list
+from . import kqml_performative
+from .kqml_token import KQMLToken
+from .kqml_string import KQMLString
+from .kqml_quotation import KQMLQuotation
 
 logger = logging.getLogger('KQMLReader')
 
@@ -19,14 +19,16 @@ class KQMLReader(object):
         self.reader.close()
 
     def read_char(self):
-        ch = self.reader.read(1)
+        # bytes -> str
+        ch = self.reader.read(1).decode()
         self.inbuf += ch
         return ch
 
     def unget_char(self, ch):
         # Rewind by 1 relative to current position
         self.reader.seek(-1, 1)
-        self.reader.write(ch)
+        # need bytes!
+        self.reader.write(ch.encode("utf-8"))
         # Rewind by 1 relative to current position
         self.reader.seek(-1, 1)
         self.inbuf = self.inbuf[:-1]

--- a/kqml/kqml_string.py
+++ b/kqml/kqml_string.py
@@ -1,4 +1,4 @@
-import StringIO
+from six import StringIO
 from kqml import KQMLObject
 
 class KQMLString(object):
@@ -29,7 +29,7 @@ class KQMLString(object):
         out.write('"')
 
     def to_string(self):
-        out = StringIO.StringIO()
+        out = StringIO()
         self.write(out)
         return out.getvalue()
 
@@ -46,4 +46,3 @@ class KQMLString(object):
 
     def __getitem__(self, *args):
         return self.data.__getitem__(*args)
-

--- a/kqml/kqml_token.py
+++ b/kqml/kqml_token.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 import re
-from kqml import KQMLObject
+from .common import KQMLObject
+from six import string_types
 
 class KQMLToken(KQMLObject):
     def __init__(self, s=None):
@@ -12,7 +14,7 @@ class KQMLToken(KQMLObject):
         return len(self.data)
 
     def equals_ignore_case(self, s):
-        if isinstance(s, KQMLToken) or isinstance(s, basestring):
+        if isinstance(s, KQMLToken) or isinstance(s, string_types):
             return (self.data.lower() == s.lower())
 
     def lower(self):

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='pykqml',
     author_email='benjamin_gyori@hms.harvard.edu',
     description='KQML messaging classes in Python.',
     long_description=open('README.rst', 'r').read(),
+    install_requires=["six"],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/tests/test_kqml_list.py
+++ b/tests/test_kqml_list.py
@@ -1,22 +1,25 @@
+from six import string_types
 from kqml.kqml_list import KQMLList
 from kqml.kqml_token import KQMLToken
+import unittest
 
-def test_init():
-    kl = KQMLList()
-    assert(kl.data == [])
-    kl = KQMLList('head')
-    assert(kl.data == ['head'])
-    assert(type(kl.data[0] == KQMLToken))
-    kl = KQMLList(['a', 'b'])
-    assert(kl.data == ['a', 'b'])
+class TestKQMLList(unittest.TestCase):
+    def test_init(self):
+        kl = KQMLList()
+        self.assertEqual(kl.data, [])
+        kl = KQMLList('head')
+        self.assertEqual(kl.data, ['head'])
+        self.assertTrue(isinstance(kl.data[0], KQMLToken))
+        kl = KQMLList(['a', 'b'])
+        self.assertEqual(kl.data, ['a', 'b'])
 
-def test_from_string():
-    s = '(FAILURE :reason INVALID_DESCRIPTION)'
-    kl = KQMLList.from_string(s)
-    for obj in kl.data:
-        assert(not(isinstance(obj, basestring)))
+    def test_from_string(self):
+        s = '(FAILURE :reason INVALID_DESCRIPTION)'
+        kl = KQMLList.from_string(s)
+        for obj in kl.data:
+            self.assertFalse(isinstance(obj, string_types))
 
-def test_gets():
-    kl = KQMLList.from_string('(:hello "")')
-    hello = kl.gets('hello')
-    assert(hello == '')
+    def test_gets(self):
+        kl = KQMLList.from_string('(:hello "")')
+        hello = kl.gets('hello')
+        self.assertEqual(hello, '')

--- a/tests/test_kqml_module.py
+++ b/tests/test_kqml_module.py
@@ -1,5 +1,7 @@
 from kqml import KQMLModule
+import unittest
 
-def test_init():
-    """Tests whether KQMLModule can be initialized."""
-    KQMLModule(testing=True, name='testmodule')
+class TestKQMLModule(unittest.TestCase):
+    def test_init(self):
+        """Tests whether KQMLModule can be initialized."""
+        KQMLModule(testing=True, name='testmodule')

--- a/tests/test_kqml_performative.py
+++ b/tests/test_kqml_performative.py
@@ -1,20 +1,22 @@
 from kqml.kqml_list import KQMLList
 from kqml.kqml_performative import KQMLPerformative
+import unittest
 
-def test_init():
-    kp = KQMLPerformative('tell')
-    assert(kp.data[0].data == 'tell')
-    kp = KQMLPerformative(KQMLList(['a', ':b', 'c']))
-    assert(kp.data[0] == 'a')
-    assert(kp.data[1] == ':b')
+class TestKQMLPerformative(unittest.TestCase):
+    def test_init(self):
+        kp = KQMLPerformative('tell')
+        self.assertEqual(kp.data[0].data, 'tell')
+        kp = KQMLPerformative(KQMLList(['a', ':b', 'c']))
+        assert(kp.data[0] == 'a')
+        assert(kp.data[1] == ':b')
 
-def test_head():
-    kp = KQMLPerformative('tell')
-    assert(kp.head() == 'tell')
-    kp = KQMLPerformative(KQMLList(['tell', ':content', KQMLList(['success'])]))
-    assert(kp.head() == 'tell')
+    def test_head(self):
+        kp = KQMLPerformative('tell')
+        self.assertEqual(kp.head(), 'tell')
+        kp = KQMLPerformative(KQMLList(['tell', ':content', KQMLList(['success'])]))
+        self.assertEqual(kp.head(), 'tell')
 
-def test_get():
-    kp = KQMLPerformative(KQMLList(['tell', ':content', KQMLList(['success'])]))
-    assert(kp.get('content').data == ['success'])
-    assert(kp.get(':content').data == ['success'])
+    def test_get(self):
+        kp = KQMLPerformative(KQMLList(['tell', ':content', KQMLList(['success'])]))
+        self.assertEqual(kp.get('content').data, ['success'])
+        self.assertEqual(kp.get(':content').data, ['success'])

--- a/tests/test_kqml_reader.py
+++ b/tests/test_kqml_reader.py
@@ -1,18 +1,22 @@
 import sys
-import StringIO
+from six import BytesIO, StringIO, string_types
 from kqml.kqml_reader import KQMLReader
 from kqml.kqml_list import KQMLList
+import unittest
 
-def test_read_list():
-    s = '(FAILURE :reason INVALID_DESCRIPTION)'
-    sreader = StringIO.StringIO(s)
-    kr = KQMLReader(sreader)
-    lst = kr.read_list()
-    for obj in lst:
-        assert(not(isinstance(obj, basestring)))
+class TestKQMLReader(unittest.TestCase):
+    def test_read_list(self):
+        s = '(FAILURE :reason INVALID_DESCRIPTION)'
+        # str -> bytes
+        sreader = BytesIO(s.encode("utf-8"))
+        kr = KQMLReader(sreader)
+        lst = kr.read_list()
+        for obj in lst:
+            assert(not(isinstance(obj, string_types)))
 
-def test_read_performative():
-    s = '(REQUEST :CONTENT (REQUEST_TYPE :CONTENT "<ekb>ONT::PROTEIN</ekb>"))'
-    sreader = StringIO.StringIO(s)
-    kr = KQMLReader(sreader)
-    kp = kr.read_performative()
+    def test_read_performative(self):
+        s = '(REQUEST :CONTENT (REQUEST_TYPE :CONTENT "<ekb>ONT::PROTEIN</ekb>"))'
+        # str -> bytes
+        sreader = BytesIO(s.encode("utf-8"))
+        kr = KQMLReader(sreader)
+        kp = kr.read_performative()

--- a/tests/test_kqml_string.py
+++ b/tests/test_kqml_string.py
@@ -1,19 +1,21 @@
 from kqml.kqml_string import KQMLString
+import unittest
 
-def test_len():
-    s = 'hello\nhe"ll"o'
-    ks = KQMLString(s)
-    assert(len(ks) == len(s))
+class TestKQMLString(unittest.TestCase):
+    def test_len(self):
+        s = 'hello\nhe"ll"o'
+        ks = KQMLString(s)
+        self.assertEqual(len(ks), len(s))
 
-def test_write():
-    s = 'hello\nhe"ll"o'
-    ks = KQMLString(s)
-    ss = ks.to_string()
-    assert(ss == '"hello\nhe\\"ll\\"o"')
-    ss = ks.string_value()
-    assert(ss == s)
+    def test_write(self):
+        s = 'hello\nhe"ll"o'
+        ks = KQMLString(s)
+        ss = ks.to_string()
+        self.assertEqual(ss, '"hello\nhe\\"ll\\"o"')
+        ss = ks.string_value()
+        self.assertEqual(ss, s)
 
-def test_getitem():
-    ks = KQMLString('hello')
-    assert(ks[0] == 'h')
-    assert(ks[-1] == 'o')
+    def test_getitem(self):
+        ks = KQMLString('hello')
+        self.assertEqual(ks[0], 'h')
+        self.assertEqual(ks[-1], 'o')

--- a/tests/test_kqml_token.py
+++ b/tests/test_kqml_token.py
@@ -1,49 +1,51 @@
 from kqml.kqml_token import KQMLToken
+import unittest
 
-def test_init():
-    kt = KQMLToken('token')
-    assert(kt.data == 'token')
-    kt = KQMLToken()
-    assert(kt.data == '')
+class TestKQMLList(unittest.TestCase):
+    def test_init(self):
+        kt = KQMLToken('token')
+        self.assertEqual(kt.data, 'token')
+        kt = KQMLToken()
+        self.assertEqual(kt.data, '')
 
-def test_len():
-    kt = KQMLToken('token')
-    assert(len(kt) == 5)
+    def test_len(self):
+        kt = KQMLToken('token')
+        self.assertEqual(len(kt), 5)
 
-def test_package():
-    kt = KQMLToken('ONT::TOKEN')
-    package, bare = kt.parse_package()
-    assert(package == 'ONT')
-    assert(bare == 'TOKEN')
-    assert(kt.has_package())
-    kt = KQMLToken('ONT::|TOKEN|')
-    package, bare = kt.parse_package()
-    assert(package == 'ONT')
-    assert(bare == '|TOKEN|')
-    assert(kt.has_package())
-    kt = KQMLToken('ONT::|TOK::EN|')
-    package, bare = kt.parse_package()
-    assert(package == 'ONT')
-    assert(bare == '|TOK::EN|')
-    assert(kt.has_package())
-    kt = KQMLToken(':keyword')
-    package, bare = kt.parse_package()
-    assert(package == None)
-    assert(bare == ':keyword')
-    assert(not kt.has_package())
+    def test_package(self):
+        kt = KQMLToken('ONT::TOKEN')
+        package, bare = kt.parse_package()
+        self.assertEqual(package, 'ONT')
+        self.assertEqual(bare, 'TOKEN')
+        self.assertTrue(kt.has_package())
+        kt = KQMLToken('ONT::|TOKEN|')
+        package, bare = kt.parse_package()
+        self.assertEqual(package, 'ONT')
+        self.assertEqual(bare, '|TOKEN|')
+        self.assertTrue(kt.has_package())
+        kt = KQMLToken('ONT::|TOK::EN|')
+        package, bare = kt.parse_package()
+        self.assertEqual(package, 'ONT')
+        self.assertEqual(bare, '|TOK::EN|')
+        self.assertTrue(kt.has_package())
+        kt = KQMLToken(':keyword')
+        package, bare = kt.parse_package()
+        self.assertIsNone(package)
+        self.assertEqual(bare, ':keyword')
+        self.assertFalse(kt.has_package())
 
-def test_is_keyword():
-    kt = KQMLToken(':keyword')
-    assert(kt.is_keyword())
-    kt = KQMLToken('token')
-    assert(not kt.is_keyword())
-    kt = KQMLToken('ONT::TOKEN')
-    assert(not kt.is_keyword())
+    def test_is_keyword(self):
+        kt = KQMLToken(':keyword')
+        self.assertTrue(kt.is_keyword())
+        kt = KQMLToken('token')
+        self.assertFalse(kt.is_keyword())
+        kt = KQMLToken('ONT::TOKEN')
+        self.assertFalse(kt.is_keyword())
 
-def test_equals():
-    assert(KQMLToken('token') == 'token')
-    assert(KQMLToken('token') != 'token1')
-    assert(KQMLToken('token') == KQMLToken('token'))
-    assert(KQMLToken('token') != KQMLToken('token1'))
-    assert(KQMLToken('token').equals_ignore_case('TOKEN'))
-    assert(KQMLToken('token').equals_ignore_case(KQMLToken('TOKEN')))
+    def test_equals(self):
+        self.assertEqual(KQMLToken('token'), 'token')
+        self.assertNotEqual(KQMLToken('token'), 'token1')
+        self.assertEqual(KQMLToken('token'), KQMLToken('token'))
+        self.assertNotEqual(KQMLToken('token'), KQMLToken('token1'))
+        self.assertTrue(KQMLToken('token').equals_ignore_case('TOKEN'))
+        self.assertTrue(KQMLToken('token').equals_ignore_case(KQMLToken('TOKEN')))


### PR DESCRIPTION
This addresses #4 

### Summary
- Added `six` as a dependency. This module solves a lot of python2->3 interoperability issues.
- Added instructions for running tests and converted all tests to use `unittests`

All tests appear to pass, although `KQMLQuotation` probably needs tests.