### PR TITLE
Update to work in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+cache:
+  directories:
+    - $HOME/.cache/pip
+python:
+  - "3.5"
+before_install:
+  - pip install nose coverage
+script:
+  - nosetests -v --with-coverage --cover-inclusive --cover-package=kqml

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,38 @@
 PyKQML
 ======
 
-PyKQML is an implementation of KQML messaging in Python. It consists of
-the following classes:
+PyKQML is an implementation of KQML messaging in Python.
+
+Installation
+============
+
+PyKQML can be installed as
+
+::
+
+    pip install pykqml
+
+Note that releases of PyKQML up to 0.5 work in Python 2 only, whereas
+releases after 0.5 work in Python 3 only.
+
+To install for Python 2, use:
+
+::
+
+    pip install pykqml==0.5
+
+To install for Python 3 (or force an upgrade to a compatible version),
+use
+
+::
+
+    pip install pykqml>0.5
+
+Usage
+=====
+
+PyKQML implements the following KQML classes, which allow constructing
+and manipulating KQML messages programmatically:
 
 ::
 
@@ -14,12 +44,6 @@ the following classes:
     KQMLReader
     KQMLDispatcher
     KQMLModule
-
-PyKQML can be installed as
-
-::
-
-    pip install pykqml
 
 You can import KQML classes as, for instance,
 

--- a/kqml/__init__.py
+++ b/kqml/__init__.py
@@ -5,15 +5,15 @@ class KQMLObject(object):
     """This is the parent class for KQML classes representing messages."""
     pass
 
-from kqml_exceptions import *
-from kqml_quotation import KQMLQuotation
-from kqml_token import KQMLToken
-from kqml_string import KQMLString
-from kqml_list import KQMLList
-from kqml_performative import KQMLPerformative
-from kqml_reader import KQMLReader
-from kqml_dispatcher import KQMLDispatcher
-from kqml_module import KQMLModule
+from .kqml_exceptions import *
+from .kqml_quotation import KQMLQuotation
+from .kqml_token import KQMLToken
+from .kqml_string import KQMLString
+from .kqml_list import KQMLList
+from .kqml_performative import KQMLPerformative
+from .kqml_reader import KQMLReader
+from .kqml_dispatcher import KQMLDispatcher
+from .kqml_module import KQMLModule
 
 logging.basicConfig(format='%(levelname)s: %(name)s - %(message)s',
                     level=logging.INFO)

--- a/kqml/__init__.py
+++ b/kqml/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5'
+__version__ = '1.0'
 import logging
 
 class KQMLObject(object):

--- a/kqml/kqml_dispatcher.py
+++ b/kqml/kqml_dispatcher.py
@@ -22,13 +22,17 @@ class KQMLDispatcher(object):
         # FIXME: not handling KQMLException and
         # KQMLBadCharacterException
         except KeyboardInterrupt:
+            logger.info('Keyboard interrupt received')
             self.receiver.receive_eof()
         except EOFError:
+            logger.info('EOF received')
             self.receiver.receive_eof()
         except IOError as ex:
             if not self.shutdown_initiated:
                 self.receiver.handle_exception(ex)
-        except ValueError:
+        except ValueError as e:
+            logger.error('Value error during reading')
+            logger.exception(e)
             return
 
     def warn(self, msg):

--- a/kqml/kqml_list.py
+++ b/kqml/kqml_list.py
@@ -3,7 +3,7 @@ from . import KQMLObject
 from .kqml_token import KQMLToken
 from .kqml_string import KQMLString
 import kqml.kqml_reader as kqml_reader
-from .util import safe_decode
+from .util import safe_decode, safe_encode
 
 class KQMLList(KQMLObject):
     def __init__(self, objects=None):
@@ -214,6 +214,7 @@ class KQMLList(KQMLObject):
 
     @classmethod
     def from_string(cls, s):
+        s = safe_encode(s)
         sreader = BytesIO(s)
         kreader = kqml_reader.KQMLReader(sreader)
         return kreader.read_list()

--- a/kqml/kqml_list.py
+++ b/kqml/kqml_list.py
@@ -93,7 +93,7 @@ class KQMLList(KQMLObject):
         """
         param = self.get(keyword)
         if param is not None:
-            return param.string_value()
+            return safe_decode(param.string_value())
         return None
 
 

--- a/kqml/kqml_list.py
+++ b/kqml/kqml_list.py
@@ -1,8 +1,9 @@
-from io import StringIO
+from io import BytesIO
 from . import KQMLObject
 from .kqml_token import KQMLToken
 from .kqml_string import KQMLString
 import kqml.kqml_reader as kqml_reader
+from .util import safe_decode
 
 class KQMLList(KQMLObject):
     def __init__(self, objects=None):
@@ -19,7 +20,8 @@ class KQMLList(KQMLObject):
             self.append(objects)
 
     def __str__(self):
-        return '(' + ' '.join([d.__str__() for d in self.data]) + ')'
+        return safe_decode('(' + ' '.join([d.__str__()
+                                           for d in self.data]) + ')')
 
     def __repr__(self):
         return '(' + ' '.join([d.__repr__() for d in self.data]) + ')'
@@ -203,16 +205,16 @@ class KQMLList(KQMLObject):
 
     def write(self, out):
         full_str = '(' + ' '.join([str(s) for s in self.data]) + ')'
-        out.write(full_str)
+        out.write(full_str.encode())
 
     def to_string(self):
-        out = StringIO()
+        out = BytesIO()
         self.write(out)
-        return out.getvalue()
+        return safe_decode(out.getvalue())
 
     @classmethod
     def from_string(cls, s):
-        sreader = StringIO(s)
+        sreader = BytesIO(s)
         kreader = kqml_reader.KQMLReader(sreader)
         return kreader.read_list()
 

--- a/kqml/kqml_list.py
+++ b/kqml/kqml_list.py
@@ -15,7 +15,7 @@ class KQMLList(KQMLObject):
             for o in objects:
                 self.append(o)
         # If a string is passed, it becomes the "head" of the list
-        elif isinstance(objects, basestring):
+        elif isinstance(objects, str):
             self.append(objects)
 
     def __str__(self):
@@ -104,7 +104,7 @@ class KQMLList(KQMLObject):
             If a string is passed, it is instantiated as a
             KQMLToken before being added to the list.
         """
-        if isinstance(obj, basestring):
+        if isinstance(obj, str):
             obj = KQMLToken(obj)
         self.data.append(obj)
 
@@ -117,7 +117,7 @@ class KQMLList(KQMLObject):
             If a string is passed, it is instantiated as a
             KQMLToken before being added to the list.
         """
-        if isinstance(obj, basestring):
+        if isinstance(obj, str):
             obj = KQMLToken(obj)
         self.data.insert(0, obj)
 
@@ -164,9 +164,9 @@ class KQMLList(KQMLObject):
         """
         if not keyword.startswith(':'):
             keyword = ':' + keyword
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             value = KQMLToken(value)
-        if isinstance(keyword, basestring):
+        if isinstance(keyword, str):
             keyword = KQMLToken(keyword)
         found = False
         for i, key in enumerate(self.data):
@@ -197,7 +197,7 @@ class KQMLList(KQMLObject):
             kl = KQMLList.from_string('(FAILURE)')
             kl.sets('reason', 'this is a custom string message, not a token')
         """
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             value = KQMLString(value)
         self.set(keyword, value)
 
@@ -222,7 +222,7 @@ class KQMLList(KQMLObject):
         return KQMLList(self.data[from_idx:to_idx])
 
     def index_of(self, obj):
-        if isinstance(obj, basestring):
+        if isinstance(obj, str):
             return self.index_of_string(obj)
         else:
             try:

--- a/kqml/kqml_list.py
+++ b/kqml/kqml_list.py
@@ -1,8 +1,8 @@
 from io import StringIO
-from kqml import KQMLObject
-from kqml_token import KQMLToken
-from kqml_string import KQMLString
-import kqml_reader
+from . import KQMLObject
+from .kqml_token import KQMLToken
+from .kqml_string import KQMLString
+import kqml.kqml_reader as kqml_reader
 
 class KQMLList(KQMLObject):
     def __init__(self, objects=None):

--- a/kqml/kqml_list.py
+++ b/kqml/kqml_list.py
@@ -1,4 +1,4 @@
-import StringIO
+from io import StringIO
 from kqml import KQMLObject
 from kqml_token import KQMLToken
 from kqml_string import KQMLString
@@ -206,13 +206,13 @@ class KQMLList(KQMLObject):
         out.write(full_str)
 
     def to_string(self):
-        out = StringIO.StringIO()
+        out = StringIO()
         self.write(out)
         return out.getvalue()
 
     @classmethod
     def from_string(cls, s):
-        sreader = StringIO.StringIO(s)
+        sreader = StringIO(s)
         kreader = kqml_reader.KQMLReader(sreader)
         return kreader.read_list()
 

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -106,9 +106,8 @@ class KQMLModule(object):
                 (self.inp, self.out)
         else:
             logger.info('Using stdio connection')
-            from _io import BytesIO
-            self.out = BytesIO()
-            self.inp = KQMLReader(BytesIO())
+            self.out = io.BytesIO()
+            self.inp = KQMLReader(io.BytesIO())
 
         self.dispatcher = KQMLDispatcher(self, self.inp, self.name)
 

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -293,7 +293,7 @@ class KQMLModule(object):
         self.error_reply(msg, 'unexpected performative: eos')
 
     def receive_error(self, msg):
-        logger.error('unexpected performative: error')
+        logger.error('Error received: "%s"' % msg)
 
     def receive_sorry(self, msg):
         logger.error('unexpected performative: sorry')

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -106,8 +106,8 @@ class KQMLModule(object):
                 (self.inp, self.out)
         else:
             logger.info('Using stdio connection')
-            self.out = sys.stdout
-            self.inp = KQMLReader(sys.stdin)
+            self.out = sys.stdout.buffer
+            self.inp = KQMLReader(sys.stdin.buffer)
 
         self.dispatcher = KQMLDispatcher(self, self.inp, self.name)
 
@@ -314,7 +314,7 @@ class KQMLModule(object):
         logger.error(msg, 'unexpected performative: unregister')
 
     def receive_other_performative(self, msg):
-        self.error_reply(msg, 'unexpected performative: ' + msg)
+        self.error_reply(msg, 'unexpected performative: ' + str(msg))
 
     def handle_exception(self, ex):
         logger.error(str(ex))
@@ -325,7 +325,7 @@ class KQMLModule(object):
         except IOError:
             logger.error('IOError during message sending')
             pass
-        self.out.write('\n')
+        self.out.write(b'\n')
         self.out.flush()
         logger.debug(msg.__repr__())
 

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -106,8 +106,9 @@ class KQMLModule(object):
                 (self.inp, self.out)
         else:
             logger.info('Using stdio connection')
-            self.out = sys.stdout.buffer
-            self.inp = KQMLReader(sys.stdin.buffer)
+            from _io import BytesIO
+            self.out = BytesIO()
+            self.inp = KQMLReader(BytesIO())
 
         self.dispatcher = KQMLDispatcher(self, self.inp, self.name)
 

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -4,7 +4,7 @@ import socket
 import logging
 from kqml import KQMLReader, KQMLDispatcher
 from kqml import KQMLList, KQMLPerformative
-from kqml_exceptions import KQMLException
+from .kqml_exceptions import KQMLException
 
 logger = logging.getLogger('KQMLModule')
 

--- a/kqml/kqml_performative.py
+++ b/kqml/kqml_performative.py
@@ -1,9 +1,11 @@
-from io import StringIO
+from io import BytesIO
 from kqml import KQMLObject
 from . import kqml_reader
 from . import kqml_list
 from .kqml_token import KQMLToken
 from .kqml_exceptions import KQMLBadPerformativeException
+from .util import safe_decode
+
 
 class KQMLPerformative(KQMLObject):
     def __init__(self, objects):
@@ -58,16 +60,16 @@ class KQMLPerformative(KQMLObject):
         self.data.write(out)
 
     def to_string(self):
-        return self.data.to_string()
+        return safe_decode(self.data.to_string())
 
     @classmethod
     def from_string(cls, s):
-        sreader = StringIO(s)
+        sreader = BytesIO(s.encode())
         kreader = kqml_reader.KQMLReader(sreader)
         return cls(kreader.read_list())
 
     def __str__(self):
-        return self.to_string()
+        return safe_decode(self.to_string())
 
     def __repr__(self):
         return self.data.__repr__()

--- a/kqml/kqml_performative.py
+++ b/kqml/kqml_performative.py
@@ -1,4 +1,4 @@
-import StringIO
+from io import StringIO
 from kqml import KQMLObject
 import kqml_reader
 import kqml_list
@@ -62,7 +62,7 @@ class KQMLPerformative(KQMLObject):
 
     @classmethod
     def from_string(cls, s):
-        sreader = StringIO.StringIO(s)
+        sreader = StringIO(s)
         kreader = kqml_reader.KQMLReader(sreader)
         return cls(kreader.read_list())
 

--- a/kqml/kqml_performative.py
+++ b/kqml/kqml_performative.py
@@ -4,7 +4,7 @@ from . import kqml_reader
 from . import kqml_list
 from .kqml_token import KQMLToken
 from .kqml_exceptions import KQMLBadPerformativeException
-from .util import safe_decode
+from .util import safe_decode, safe_encode
 
 
 class KQMLPerformative(KQMLObject):
@@ -64,7 +64,8 @@ class KQMLPerformative(KQMLObject):
 
     @classmethod
     def from_string(cls, s):
-        sreader = BytesIO(s.encode())
+        s = safe_encode(s)
+        sreader = BytesIO(s)
         kreader = kqml_reader.KQMLReader(sreader)
         return cls(kreader.read_list())
 

--- a/kqml/kqml_performative.py
+++ b/kqml/kqml_performative.py
@@ -10,7 +10,7 @@ class KQMLPerformative(KQMLObject):
         if not objects:
             raise KQMLBadPerformativeException('no elements for initialization')
         # If we get a string then we start a list with the string as the head
-        if isinstance(objects, basestring):
+        if isinstance(objects, str):
             self.data = kqml_list.KQMLList(objects)
         elif isinstance(objects, kqml_list.KQMLList):
             self._validate(objects)

--- a/kqml/kqml_performative.py
+++ b/kqml/kqml_performative.py
@@ -1,9 +1,9 @@
 from io import StringIO
 from kqml import KQMLObject
-import kqml_reader
-import kqml_list
-from kqml_token import KQMLToken
-from kqml_exceptions import KQMLBadPerformativeException
+from . import kqml_reader
+from . import kqml_list
+from .kqml_token import KQMLToken
+from .kqml_exceptions import KQMLBadPerformativeException
 
 class KQMLPerformative(KQMLObject):
     def __init__(self, objects):

--- a/kqml/kqml_quotation.py
+++ b/kqml/kqml_quotation.py
@@ -1,4 +1,4 @@
-import StringIO
+from io import StringIO
 from kqml import KQMLObject
 
 class KQMLQuotation(KQMLObject):
@@ -17,6 +17,6 @@ class KQMLQuotation(KQMLObject):
         self.kqml_object.write(out)
 
     def to_string(self):
-        out = StringIO.StringIO()
+        out = StringIO()
         self.write(out)
         return out.getvalue()

--- a/kqml/kqml_reader.py
+++ b/kqml/kqml_reader.py
@@ -36,7 +36,7 @@ class KQMLReader(object):
             ch_ = self.reader.peek(1)
             if not ch_:
                 raise EOFError
-            ch = bytes(ch_[0]).decode()
+            ch = bytes([ch_[0]]).decode()
         else:
             ch = self.read_char()
             self.unget_char(ch)

--- a/kqml/kqml_reader.py
+++ b/kqml/kqml_reader.py
@@ -20,13 +20,13 @@ class KQMLReader(object):
 
     def read_char(self):
         ch = self.reader.read(1)
-        self.inbuf += ch
-        return ch
+        self.inbuf += ch.decode()
+        return ch.decode()
 
     def unget_char(self, ch):
         # Rewind by 1 relative to current position
         self.reader.seek(-1, 1)
-        self.reader.write(ch)
+        self.reader.write(ch.encode())
         # Rewind by 1 relative to current position
         self.reader.seek(-1, 1)
         self.inbuf = self.inbuf[:-1]
@@ -36,7 +36,7 @@ class KQMLReader(object):
             ch_ = self.reader.peek(1)
             if not ch_:
                 raise EOFError
-            ch = ch_[0]
+            ch = bytes(ch_[0]).decode()
         else:
             ch = self.read_char()
             self.unget_char(ch)

--- a/kqml/kqml_reader.py
+++ b/kqml/kqml_reader.py
@@ -1,12 +1,12 @@
 import io
 import logging
-from kqml_exceptions import *
+from .kqml_exceptions import *
 
-import kqml_list
-import kqml_performative
-from kqml_token import KQMLToken
-from kqml_string import KQMLString
-from kqml_quotation import KQMLQuotation
+from . import kqml_list
+from . import kqml_performative
+from .kqml_token import KQMLToken
+from .kqml_string import KQMLString
+from .kqml_quotation import KQMLQuotation
 
 logger = logging.getLogger('KQMLReader')
 

--- a/kqml/kqml_reader.py
+++ b/kqml/kqml_reader.py
@@ -20,16 +20,24 @@ class KQMLReader(object):
 
     def read_char(self):
         ch = self.reader.read(1)
+        ch_int = ch[0]
+        if ch_int >= 192 and ch_int < 224:
+            ch += self.reader.read(1)
+        elif ch_int >= 224 and ch_int < 240:
+            ch += self.reader.read(2)
+        elif ch_int >= 240:
+            ch += self.reader.read(3)
         self.inbuf += ch.decode()
         return ch.decode()
 
     def unget_char(self, ch):
+        nbytes = len(ch.encode())
         # Rewind by 1 relative to current position
-        self.reader.seek(-1, 1)
+        self.reader.seek(-nbytes, 1)
         self.reader.write(ch.encode())
         # Rewind by 1 relative to current position
-        self.reader.seek(-1, 1)
-        self.inbuf = self.inbuf[:-1]
+        self.reader.seek(-nbytes, 1)
+        self.inbuf = self.inbuf[:-nbytes]
 
     def peek_char(self):
         if isinstance(self.reader, io.BufferedReader):

--- a/kqml/kqml_string.py
+++ b/kqml/kqml_string.py
@@ -1,4 +1,4 @@
-import StringIO
+from io import StringIO
 from kqml import KQMLObject
 
 class KQMLString(object):
@@ -29,7 +29,7 @@ class KQMLString(object):
         out.write('"')
 
     def to_string(self):
-        out = StringIO.StringIO()
+        out = StringIO()
         self.write(out)
         return out.getvalue()
 

--- a/kqml/kqml_string.py
+++ b/kqml/kqml_string.py
@@ -1,12 +1,13 @@
-from io import StringIO
+from io import BytesIO
 from kqml import KQMLObject
+from .util import safe_decode
 
 class KQMLString(object):
     def __init__(self, data=None):
         if data is None:
-            self.data = ''
+            self.data = b''
         else:
-            self.data = data
+            self.data = safe_decode(data)
 
     def __len__(self):
         return len(self.data)
@@ -21,23 +22,23 @@ class KQMLString(object):
             return obj.data == self.data
 
     def write(self, out):
-        out.write('"')
+        out.write(b'"')
         for ch in self.data:
             if ch == '"':
-                out.write('\\')
-            out.write(ch)
-        out.write('"')
+                out.write(b'\\')
+            out.write(ch.encode())
+        out.write(b'"')
 
     def to_string(self):
-        out = StringIO()
+        out = BytesIO()
         self.write(out)
-        return out.getvalue()
+        return safe_decode(out.getvalue())
 
     def string_value(self):
         return self.data
 
     def __str__(self):
-        return self.to_string()
+        return safe_decode(self.to_string())
 
     def __repr__(self):
         s = self.__str__()

--- a/kqml/kqml_string.py
+++ b/kqml/kqml_string.py
@@ -5,7 +5,7 @@ from .util import safe_decode
 class KQMLString(object):
     def __init__(self, data=None):
         if data is None:
-            self.data = b''
+            self.data = ''
         else:
             self.data = safe_decode(data)
 

--- a/kqml/kqml_token.py
+++ b/kqml/kqml_token.py
@@ -12,7 +12,7 @@ class KQMLToken(KQMLObject):
         return len(self.data)
 
     def equals_ignore_case(self, s):
-        if isinstance(s, KQMLToken) or isinstance(s, basestring):
+        if isinstance(s, KQMLToken) or isinstance(s, str):
             return (self.data.lower() == s.lower())
 
     def lower(self):

--- a/kqml/kqml_token.py
+++ b/kqml/kqml_token.py
@@ -7,7 +7,7 @@ class KQMLToken(KQMLObject):
         if s is None:
             self.data = ''
         else:
-            self.data = s
+            self.data = safe_decode(s)
 
     def __len__(self):
         return len(self.data)
@@ -23,7 +23,7 @@ class KQMLToken(KQMLObject):
         return self.data.upper()
 
     def write(self, out):
-        out.write(self.data)
+        out.write(self.data.encode())
 
     def to_string(self):
         return self.data

--- a/kqml/kqml_token.py
+++ b/kqml/kqml_token.py
@@ -1,5 +1,6 @@
 import re
 from kqml import KQMLObject
+from .util import safe_decode
 
 class KQMLToken(KQMLObject):
     def __init__(self, s=None):
@@ -60,7 +61,7 @@ class KQMLToken(KQMLObject):
         return self.data.__getitem__(*args)
 
     def __str__(self):
-        return self.to_string()
+        return safe_decode(self.to_string())
 
     def __repr__(self):
         return self.to_string()

--- a/kqml/util.py
+++ b/kqml/util.py
@@ -1,0 +1,14 @@
+def safe_decode(txt):
+    """Return decoded text if it's not already bytes."""
+    try:
+        return txt.decode()
+    except AttributeError:
+        return txt
+
+
+def safe_encode(txt):
+    """Return encoded text if it's not already str."""
+    try:
+        return txt.encode()
+    except AttributeError:
+        return txt

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='pykqml',
-    version='0.5',
+    version='1.0',
     packages=['kqml'],
     keywords=['kqml', 'agent', 'nlp', 'communication', 'dialogue'],
     url='http://github.com/bgyori/pykqml',
@@ -15,6 +15,6 @@ setup(name='pykqml',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         ]
 )

--- a/tests/test_kqml_list.py
+++ b/tests/test_kqml_list.py
@@ -1,3 +1,4 @@
+from kqml import KQMLObject
 from kqml.kqml_list import KQMLList
 from kqml.kqml_token import KQMLToken
 
@@ -11,12 +12,12 @@ def test_init():
     assert(kl.data == ['a', 'b'])
 
 def test_from_string():
-    s = '(FAILURE :reason INVALID_DESCRIPTION)'
+    s = b'(FAILURE :reason INVALID_DESCRIPTION)'
     kl = KQMLList.from_string(s)
     for obj in kl.data:
-        assert(not(isinstance(obj, basestring)))
+        assert(isinstance(obj, KQMLObject))
 
 def test_gets():
-    kl = KQMLList.from_string('(:hello "")')
+    kl = KQMLList.from_string(b'(:hello "")')
     hello = kl.gets('hello')
     assert(hello == '')

--- a/tests/test_kqml_reader.py
+++ b/tests/test_kqml_reader.py
@@ -17,3 +17,10 @@ def test_read_performative():
     sreader = BytesIO(s)
     kr = KQMLReader(sreader)
     kp = kr.read_performative()
+
+def test_read_performative_utf8():
+    s = '(REQUEST :CONTENT (REQUEST_TYPE :CONTENT "<ekb>\U0001F4A9</ekb>"))'
+    s = s.encode('utf-8')
+    sreader = BytesIO(s)
+    kr = KQMLReader(sreader)
+    kp = kr.read_performative()

--- a/tests/test_kqml_reader.py
+++ b/tests/test_kqml_reader.py
@@ -1,18 +1,19 @@
 import sys
-from io import StringIO
+from io import BytesIO
+from kqml import KQMLObject
 from kqml.kqml_reader import KQMLReader
 from kqml.kqml_list import KQMLList
 
 def test_read_list():
-    s = '(FAILURE :reason INVALID_DESCRIPTION)'
-    sreader = StringIO(s)
+    s = b'(FAILURE :reason INVALID_DESCRIPTION)'
+    sreader = BytesIO(s)
     kr = KQMLReader(sreader)
     lst = kr.read_list()
     for obj in lst:
-        assert(not(isinstance(obj, basestring)))
+        assert isinstance(obj, KQMLObject)
 
 def test_read_performative():
-    s = '(REQUEST :CONTENT (REQUEST_TYPE :CONTENT "<ekb>ONT::PROTEIN</ekb>"))'
-    sreader = StringIO(s)
+    s = b'(REQUEST :CONTENT (REQUEST_TYPE :CONTENT "<ekb>ONT::PROTEIN</ekb>"))'
+    sreader = BytesIO(s)
     kr = KQMLReader(sreader)
     kp = kr.read_performative()

--- a/tests/test_kqml_reader.py
+++ b/tests/test_kqml_reader.py
@@ -1,11 +1,11 @@
 import sys
-import StringIO
+from io import StringIO
 from kqml.kqml_reader import KQMLReader
 from kqml.kqml_list import KQMLList
 
 def test_read_list():
     s = '(FAILURE :reason INVALID_DESCRIPTION)'
-    sreader = StringIO.StringIO(s)
+    sreader = StringIO(s)
     kr = KQMLReader(sreader)
     lst = kr.read_list()
     for obj in lst:
@@ -13,6 +13,6 @@ def test_read_list():
 
 def test_read_performative():
     s = '(REQUEST :CONTENT (REQUEST_TYPE :CONTENT "<ekb>ONT::PROTEIN</ekb>"))'
-    sreader = StringIO.StringIO(s)
+    sreader = StringIO(s)
     kr = KQMLReader(sreader)
     kp = kr.read_performative()

--- a/tests/test_kqml_string.py
+++ b/tests/test_kqml_string.py
@@ -9,7 +9,7 @@ def test_write():
     s = 'hello\nhe"ll"o'
     ks = KQMLString(s)
     ss = ks.to_string()
-    assert(ss == '"hello\nhe\\"ll\\"o"')
+    assert ss == '"hello\nhe\\"ll\\"o"'
     ss = ks.string_value()
     assert(ss == s)
 


### PR DESCRIPTION
This PR makes the code work in Python 3, the main changes being:
- BytesIO used for all I/O operations
- All input is decoded and internally represented as str, all output is encoded
- Parsing KQML Strings from an input stream (typically socket) assumes variable character length UTF-8 encoding
- Standard Python 3 updates like import paths