### PR TITLE
Add support for Windows sockets

### DIFF
--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -1,4 +1,5 @@
 import io
+import os
 import sys
 import socket
 import logging
@@ -7,6 +8,15 @@ from kqml import KQMLList, KQMLPerformative
 from .kqml_exceptions import KQMLException
 
 logger = logging.getLogger('KQMLModule')
+
+
+# On Windows, sockets need to be created via the msvcrt
+# package. We try to import it here and use it if available.
+try:
+    import msvcrt
+    use_msvcrt = True
+except ImportError:
+    use_msvcrt = False
 
 
 def translate_argv(raw_args):
@@ -155,14 +165,22 @@ class KQMLModule(object):
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.connect((host, port))
             sfn = self.socket.makefile().fileno()
-            fio = io.FileIO(sfn, mode='w')
-            self.out = io.BufferedWriter(fio)
-            fio = io.FileIO(sfn, mode='r')
-            self.inp = KQMLReader(io.BufferedReader(fio))
+            if use_msvcrt:
+                sfd = msvcrt.open_osfhandle(sfn, os.O_APPEND)
+                fio = io.FileIO(sfd, mode='w')
+                self.out = io.BufferedWriter(fio)
+                sfd = msvcrt.open_osfhandle(sfn, os.O_RDONLY)
+                fio = io.FileIO(sfd, mode='r')
+                self.inp = KQMLReader(io.BufferedReader(fio))
+            else:
+                fio = io.FileIO(sfn, mode='w')
+                self.out = io.BufferedWriter(fio)
+                fio = io.FileIO(sfn, mode='r')
+                self.inp = KQMLReader(io.BufferedReader(fio))
             return True
         except socket.error as e:
             if verbose:
-                logger.error(e)
+                logger.exception(e)
             return False
 
     def register(self):

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -180,7 +180,7 @@ class KQMLModule(object):
             return True
         except socket.error as e:
             if verbose:
-                logger.exception(e)
+                logger.error(e)
             return False
 
     def register(self):


### PR DESCRIPTION
This PR handles sockets on Windows using the `msvcrt` package. Fixes #10.