### PR TITLE
Use SocketIO, which works on Linux and Windows. Also fix typo

### DIFF
--- a/kqml/kqml_dispatcher.py
+++ b/kqml/kqml_dispatcher.py
@@ -89,7 +89,7 @@ class KQMLDispatcher(object):
             for cmt in msg_only_types:
                 self.receiver.__getattribute__(method_name)(msg)
         else:
-            self.receiver.recieve_other_performative(msg)
+            self.receiver.receive_other_performative(msg)
 
         return
 

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -164,19 +164,10 @@ class KQMLModule(object):
         try:
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.connect((host, port))
-            sfn = self.socket.makefile().fileno()
-            if use_msvcrt:
-                sfd = msvcrt.open_osfhandle(sfn, os.O_APPEND)
-                fio = io.FileIO(sfd, mode='w')
-                self.out = io.BufferedWriter(fio)
-                sfd = msvcrt.open_osfhandle(sfn, os.O_RDONLY)
-                fio = io.FileIO(sfd, mode='r')
-                self.inp = KQMLReader(io.BufferedReader(fio))
-            else:
-                fio = io.FileIO(sfn, mode='w')
-                self.out = io.BufferedWriter(fio)
-                fio = io.FileIO(sfn, mode='r')
-                self.inp = KQMLReader(io.BufferedReader(fio))
+            sw = socket.SocketIO(self.socket, 'w')
+            self.out = io.BufferedWriter(sw)
+            sr = socket.SocketIO(self.socket, 'r')
+            self.inp = KQMLReader(io.BufferedReader(sr))
             return True
         except socket.error as e:
             if verbose:


### PR DESCRIPTION
The fix I proposed for sockets on Windows was incomplete, as one is not able to write to the FileIO.  A solution that works on both Linux and Windows is to use socket.SocketIO.

Also, I found a typo in the dispatcher, with 'i' and 'e' swapped in a receive.
