### PR TITLE
Add a new option for the handling of bools.

### DIFF
--- a/kqml/cl_json.py
+++ b/kqml/cl_json.py
@@ -100,7 +100,9 @@ class CLJsonConverter(object):
             if s == 'NIL':
                 # This could be either false or None. Because None will almost
                 # always have the same meaning as False in pep-8 compliant
-                # python, but not vice-versa, we choose None.
+                # python, but not vice-versa, we choose None. To avoid this,
+                # you can set `token_bools` to True on your converter class,
+                # and True will be mapped to the token TRUE and False to FALSE.
                 ret = None
             elif (not self.token_bools and s == 'T') \
                     or (self.token_bools and s == 'TRUE'):

--- a/kqml/cl_json.py
+++ b/kqml/cl_json.py
@@ -7,20 +7,126 @@ from .kqml_token import KQMLToken
 from .kqml_exceptions import KQMLException
 
 
-def cl_from_json(json_obj):
-    """Read a json into a KQMLList object, recursively usng the CLJson paradigm.
+class CLJsonConverter(object):
+    def __init__(self, token_bools=False):
+        self.token_bools = token_bools
 
-    Note: both false an None are mapped to NIL. This means parsing back will
-    not have exactly the same result as the original json dict/list, in some
-    cases.
-    """
-    if isinstance(json_obj, str):
-        json_obj = json.loads(json_obj)
-    elif isinstance(json_obj, bytes):
-        json_obj = json.loads(json_obj.decode('utf-8'))
-    elif not isinstance(json_obj, list) and not isinstance(json_obj, dict):
-        raise ValueError("Input must be a list, dict, or string/bytes json.")
-    return _cl_from_json(json_obj)
+    def cl_from_json(self, json_obj):
+        """Read a json into a KQMLList, recursively using the CLJson paradigm.
+
+        Note: both false an None are mapped to NIL. This means parsing back will
+        not have exactly the same result as the original json dict/list, in some
+        cases.
+        """
+        if isinstance(json_obj, str):
+            json_obj = json.loads(json_obj)
+        elif isinstance(json_obj, bytes):
+            json_obj = json.loads(json_obj.decode('utf-8'))
+        elif not isinstance(json_obj, list) and not isinstance(json_obj, dict):
+            raise ValueError("Input must be list, dict, or string/bytes json.")
+        return self._cl_from_json(json_obj)
+
+    def _cl_from_json(self, json_obj):
+        if isinstance(json_obj, list):
+            ret = KQMLList()
+            for elem in json_obj:
+                ret.append(self._cl_from_json(elem))
+        elif isinstance(json_obj, dict):
+            ret = KQMLList()
+            for key, val in json_obj.items():
+                ret.set(_key_from_string(key), self._cl_from_json(val))
+        elif isinstance(json_obj, str):
+            ret = KQMLString(json_obj)
+        elif isinstance(json_obj, bool):
+            if json_obj:
+                if self.token_bools:
+                    ret = KQMLToken('TRUE')
+                else:
+                    ret = KQMLToken('T')
+            else:
+                if self.token_bools:
+                    ret = KQMLToken('FALSE')
+                else:
+                    ret = KQMLToken('NIL')
+        elif isinstance(json_obj, int) or isinstance(json_obj, float):
+            ret = str(json_obj)
+        elif json_obj is None:
+            return KQMLToken('NIL')
+        else:
+            raise KQMLException("Unexpected value %s of type %s."
+                                % (json_obj, type(json_obj)))
+        return ret
+
+    def cl_to_json(self, kqml_list):
+        """Recursively convert a KQMLList into a json-style dict/list.
+
+        Note: Because NIL is used as both None and False in lisp, all NIL is
+        returned as None, even if the value was intended, or originally, False.
+        """
+        if not isinstance(kqml_list, KQMLList):
+            raise ValueError("Only a KQMLList might be converted into json.")
+        return self._cl_to_json(kqml_list)
+
+    def _cl_to_json(self, kqml_thing):
+        if isinstance(kqml_thing, KQMLList):
+            # Find all possible keys (things that start with ":")
+            possible_keys = re.findall(':([^\s]+)', kqml_thing.to_string())
+
+            # Determine the true keys by checking we can actually get something
+            # from them.
+            true_key_values = []
+            for k in possible_keys:
+                val = kqml_thing.get(k)
+                if val is not None:
+                    true_key_values.append((k, val))
+
+            # Extract the return value.
+            if len(true_key_values) == len(kqml_thing)/2:
+                # It's a dict!
+                ret = {}
+                for key, val in true_key_values:
+                    ret[_string_from_key(key)] = self._cl_to_json(val)
+            elif not len(true_key_values):
+                # It's a list!
+                ret = []
+                for item in kqml_thing:
+                    ret.append(self._cl_to_json(item))
+            else:
+                # It's not valid for json.
+                raise KQMLException("Cannot convert %s into json, neither "
+                                    "list nor dict." % kqml_thing.to_string())
+        elif isinstance(kqml_thing, KQMLToken):
+            s = kqml_thing.to_string()
+            if s == 'NIL':
+                # This could be either false or None. Because None will almost
+                # always have the same meaning as False in pep-8 compliant
+                # python, but not vice-versa, we choose None.
+                ret = None
+            elif (not self.token_bools and s == 'T') \
+                    or (self.token_bools and s == 'TRUE'):
+                ret = True
+            elif self.token_bools and s == 'FALSE':
+                ret = False
+            elif s.isdigit():
+                ret = int(s)
+            elif s.count('.') == 1 and all(seg.isdigit()
+                                           for seg in s.split('.')):
+                ret = float(s)
+            else:
+                ret = s
+        elif isinstance(kqml_thing, KQMLString):
+            s = kqml_thing.string_value()
+            if s.isdigit():
+                ret = int(s)
+            elif s.count('.') == 1 and all(seg.isdigit()
+                                           for seg in s.split('.')):
+                ret = float(s)
+            else:
+                ret = s
+        else:
+            raise KQMLException("Unexpected value %s of type %s."
+                                % (kqml_thing, type(kqml_thing)))
+        return ret
 
 
 JSON_TO_CL_PATTS = [
@@ -54,43 +160,6 @@ def _key_from_string(key):
     return key.upper()
 
 
-def _cl_from_json(json_obj):
-    if isinstance(json_obj, list):
-        ret = KQMLList()
-        for elem in json_obj:
-            ret.append(_cl_from_json(elem))
-    elif isinstance(json_obj, dict):
-        ret = KQMLList()
-        for key, val in json_obj.items():
-            ret.set(_key_from_string(key), _cl_from_json(val))
-    elif isinstance(json_obj, str):
-        ret = KQMLString(json_obj)
-    elif isinstance(json_obj, bool):
-        if json_obj:
-            ret = KQMLToken('T')
-        else:
-            ret = KQMLToken('NIL')
-    elif isinstance(json_obj, int) or isinstance(json_obj, float):
-        ret = str(json_obj)
-    elif json_obj is None:
-        return KQMLToken('NIL')
-    else:
-        raise KQMLException("Unexpected value %s of type %s."
-                            % (json_obj, type(json_obj)))
-    return ret
-
-
-def cl_to_json(kqml_list):
-    """Recursively convert a KQMLList into a json-style dict/list.
-
-    Note: Because NIL is used as both None and False in lisp, all NIL is
-    returned as None, even if the value was intended, or originally, False.
-    """
-    if not isinstance(kqml_list, KQMLList):
-        raise ValueError("Only a KQMLList might be converted into json.")
-    return _cl_to_json(kqml_list)
-
-
 CL_TO_JSON_PATTS = [
     # Replacy -- with _
     (re.compile('(--)'), '_'),
@@ -115,58 +184,3 @@ def _string_from_key(s):
     return s
 
 
-def _cl_to_json(kqml_thing):
-    if isinstance(kqml_thing, KQMLList):
-        # Find all possible keys (things that start with ":")
-        possible_keys = re.findall(':([^\s]+)', kqml_thing.to_string())
-
-        # Determine the true keys by checking we can actually get something
-        # from them.
-        true_key_values = []
-        for k in possible_keys:
-            val = kqml_thing.get(k)
-            if val is not None:
-                true_key_values.append((k, val))
-
-        # Extract the return value.
-        if len(true_key_values) == len(kqml_thing)/2:
-            # It's a dict!
-            ret = {}
-            for key, val in true_key_values:
-                ret[_string_from_key(key)] = _cl_to_json(val)
-        elif not len(true_key_values):
-            # It's a list!
-            ret = []
-            for item in kqml_thing:
-                ret.append(_cl_to_json(item))
-        else:
-            # It's not valid for json.
-            raise KQMLException("Cannot convert %s into json, neither list "
-                                "nor dict." % kqml_thing.to_string())
-    elif isinstance(kqml_thing, KQMLToken):
-        s = kqml_thing.to_string()
-        if s == 'NIL':
-            # This could be either false or None. Because None will almost
-            # always have the same meaning as False in pep-8 compliant python,
-            # but not vice-versa, we choose None.
-            ret = None
-        elif s == 'T':
-            ret = True
-        elif s.isdigit():
-            ret = int(s)
-        elif s.count('.') == 1 and all(seg.isdigit() for seg in s.split('.')):
-            ret = float(s)
-        else:
-            ret = s
-    elif isinstance(kqml_thing, KQMLString):
-        s = kqml_thing.string_value()
-        if s.isdigit():
-            ret = int(s)
-        elif s.count('.') == 1 and all(seg.isdigit() for seg in s.split('.')):
-            ret = float(s)
-        else:
-            ret = s
-    else:
-        raise KQMLException("Unexpected value %s of type %s."
-                            % (kqml_thing, type(kqml_thing)))
-    return ret

--- a/kqml/cl_json.py
+++ b/kqml/cl_json.py
@@ -117,14 +117,7 @@ class CLJsonConverter(object):
             else:
                 ret = s
         elif isinstance(kqml_thing, KQMLString):
-            s = kqml_thing.string_value()
-            if s.isdigit():
-                ret = int(s)
-            elif s.count('.') == 1 and all(seg.isdigit()
-                                           for seg in s.split('.')):
-                ret = float(s)
-            else:
-                ret = s
+            ret = kqml_thing.string_value()
         else:
             raise KQMLException("Unexpected value %s of type %s."
                                 % (kqml_thing, type(kqml_thing)))

--- a/tests/test_cl_json.py
+++ b/tests/test_cl_json.py
@@ -1,6 +1,7 @@
 import sys
 
 from kqml import cl_json, KQMLList
+from kqml.cl_json import CLJsonConverter
 
 
 def _equal(json_val, back_json_val):
@@ -33,27 +34,29 @@ def _equal(json_val, back_json_val):
 
 
 def test_simple_parse():
+    converter = CLJsonConverter()
     json_dict = {'a': 1, 'b': 2,
                  'c': ['foo', {'bar': None, 'done': False}],
                  'this_is_json': True}
-    res = cl_json._cl_from_json(json_dict)
+    res = converter.cl_from_json(json_dict)
     print('CL JSON Result:', res.to_string())
     assert isinstance(res, KQMLList)
     assert len(res) == 2*len(json_dict.keys())
-    back_dict = cl_json.cl_to_json(res)
+    back_dict = converter.cl_to_json(res)
     assert len(back_dict) == len(json_dict)
     assert _equal(json_dict, back_dict)
 
 
 def test_more_complex_parse():
+    converter = CLJsonConverter()
     json_dict = {'a': 1, 'B': 2,
                  'c': ['f oo -_?+@(*^&@#^$', {'Bar': None, 'DONE': False}],
                  'This_isJson': True}
-    res = cl_json._cl_from_json(json_dict)
+    res = converter.cl_from_json(json_dict)
     print("CL JSON Result:", res.to_string())
     assert isinstance(res, KQMLList)
     assert len(res) == 2*len(json_dict.keys())
-    back_dict = cl_json.cl_to_json(res)
+    back_dict = converter.cl_to_json(res)
     assert len(back_dict) == len(json_dict)
     assert _equal(json_dict, back_dict)
 

--- a/tests/test_cl_json.py
+++ b/tests/test_cl_json.py
@@ -39,60 +39,56 @@ def _equal(json_val, back_json_val, strict=False):
     return ret
 
 
+EASY_JSON = {'a': 1, 'b': 2, 'number': '12',
+             'c': ['foo', {'bar': None, 'done': False}],
+             'this_is_json': True}
+HARD_JSON = {'a': 1, 'B': 2, 'number1': '12',
+             'c': ['f oo -_?+@(*^&@#^$', {'Bar': None, 'DONE': False}],
+             'This_isJson': True}
+
+
 def test_simple_parse():
     converter = CLJsonConverter()
-    json_dict = {'a': 1, 'b': 2,
-                 'c': ['foo', {'bar': None, 'done': False}],
-                 'this_is_json': True}
-    res = converter.cl_from_json(json_dict)
+    res = converter.cl_from_json(EASY_JSON)
     print('CL JSON Result:', res.to_string())
     assert isinstance(res, KQMLList)
-    assert len(res) == 2*len(json_dict.keys())
+    assert len(res) == 2*len(EASY_JSON.keys())
     back_dict = converter.cl_to_json(res)
-    assert len(back_dict) == len(json_dict)
-    assert _equal(json_dict, back_dict)
+    assert len(back_dict) == len(EASY_JSON)
+    assert _equal(EASY_JSON, back_dict)
 
 
 def test_more_complex_parse():
     converter = CLJsonConverter()
-    json_dict = {'a': 1, 'B': 2,
-                 'c': ['f oo -_?+@(*^&@#^$', {'Bar': None, 'DONE': False}],
-                 'This_isJson': True}
-    res = converter.cl_from_json(json_dict)
+    res = converter.cl_from_json(HARD_JSON)
     print("CL JSON Result:", res.to_string())
     assert isinstance(res, KQMLList)
-    assert len(res) == 2*len(json_dict.keys())
+    assert len(res) == 2*len(HARD_JSON.keys())
     back_dict = converter.cl_to_json(res)
-    assert len(back_dict) == len(json_dict)
-    assert _equal(json_dict, back_dict)
+    assert len(back_dict) == len(HARD_JSON)
+    assert _equal(HARD_JSON, back_dict)
 
 
 def test_simple_parse_w_token_bools():
     converter = CLJsonConverter(True)
-    json_dict = {'a': 1, 'b': 2,
-                 'c': ['foo', {'bar': None, 'done': False}],
-                 'this_is_json': True}
-    res = converter.cl_from_json(json_dict)
+    res = converter.cl_from_json(EASY_JSON)
     print('CL JSON Result:', res.to_string())
     assert isinstance(res, KQMLList)
-    assert len(res) == 2*len(json_dict.keys())
+    assert len(res) == 2*len(EASY_JSON.keys())
     back_dict = converter.cl_to_json(res)
-    assert len(back_dict) == len(json_dict)
-    assert _equal(json_dict, back_dict, strict=True)
+    assert len(back_dict) == len(EASY_JSON)
+    assert _equal(EASY_JSON, back_dict, strict=True)
 
 
 def test_more_complex_parse_w_token_bools():
     converter = CLJsonConverter(True)
-    json_dict = {'a': 1, 'B': 2,
-                 'c': ['f oo -_?+@(*^&@#^$', {'Bar': None, 'DONE': False}],
-                 'This_isJson': True}
-    res = converter.cl_from_json(json_dict)
+    res = converter.cl_from_json(HARD_JSON)
     print("CL JSON Result:", res.to_string())
     assert isinstance(res, KQMLList)
-    assert len(res) == 2*len(json_dict.keys())
+    assert len(res) == 2*len(HARD_JSON.keys())
     back_dict = converter.cl_to_json(res)
-    assert len(back_dict) == len(json_dict)
-    assert _equal(json_dict, back_dict, strict=True)
+    assert len(back_dict) == len(HARD_JSON)
+    assert _equal(HARD_JSON, back_dict, strict=True)
 
 
 def _check_convert(inp, exp):

--- a/tests/test_cl_json.py
+++ b/tests/test_cl_json.py
@@ -4,24 +4,30 @@ from kqml import cl_json, KQMLList
 from kqml.cl_json import CLJsonConverter
 
 
-def _equal(json_val, back_json_val):
-    if json_val is False and back_json_val is None:
-        return True
+def _equal(json_val, back_json_val, strict=False):
+    # This handles the case where False->NIL which is not reliably
+    # back-translated.
+    if not strict:
+        if json_val is False and back_json_val is None:
+            return True
+
+    # Make sure the types are the same.
     if type(json_val) != type(back_json_val):
         print("Mismatched type:", type(json_val), type(back_json_val))
         return False
 
+    # Check for equalities of values (recursively)
     if isinstance(json_val, dict):
         ret = True
         for key, value in json_val.items():
-            if not _equal(value, back_json_val[key]):
+            if not _equal(value, back_json_val[key], strict):
                 print("Dict at %s:" % key, value, back_json_val[key])
                 ret = False
                 break
     elif isinstance(json_val, list):
         ret = True
         for i, value in enumerate(json_val):
-            if not _equal(value, back_json_val[i]):
+            if not _equal(value, back_json_val[i], strict):
                 print("List at %s:" % i, value, back_json_val[i])
                 ret = False
                 break
@@ -59,6 +65,34 @@ def test_more_complex_parse():
     back_dict = converter.cl_to_json(res)
     assert len(back_dict) == len(json_dict)
     assert _equal(json_dict, back_dict)
+
+
+def test_simple_parse_w_token_bools():
+    converter = CLJsonConverter(True)
+    json_dict = {'a': 1, 'b': 2,
+                 'c': ['foo', {'bar': None, 'done': False}],
+                 'this_is_json': True}
+    res = converter.cl_from_json(json_dict)
+    print('CL JSON Result:', res.to_string())
+    assert isinstance(res, KQMLList)
+    assert len(res) == 2*len(json_dict.keys())
+    back_dict = converter.cl_to_json(res)
+    assert len(back_dict) == len(json_dict)
+    assert _equal(json_dict, back_dict, strict=True)
+
+
+def test_more_complex_parse_w_token_bools():
+    converter = CLJsonConverter(True)
+    json_dict = {'a': 1, 'B': 2,
+                 'c': ['f oo -_?+@(*^&@#^$', {'Bar': None, 'DONE': False}],
+                 'This_isJson': True}
+    res = converter.cl_from_json(json_dict)
+    print("CL JSON Result:", res.to_string())
+    assert isinstance(res, KQMLList)
+    assert len(res) == 2*len(json_dict.keys())
+    back_dict = converter.cl_to_json(res)
+    assert len(back_dict) == len(json_dict)
+    assert _equal(json_dict, back_dict, strict=True)
 
 
 def _check_convert(inp, exp):


### PR DESCRIPTION
Previously, and still by default, False was mapped to NIL, which is LISP's native for both False and None. This resulted in ambiguity when converting CL JSON to JSON. This PR refactors the two key functions, `cl_to_json` and `cl_from_json` to be methods of a class `CLJsonConverter`, which may be instantiated with `token_bools` set to True or False. If False (the default), the aforementioned behavior is preserved, but if not, bools  are converted naturally to the tokens TRUE and FALSE, thus avoiding the ambiguity.

This PR also fixes a bug where strings of numbers were converted to numbers.