### PR TITLE
Add method for dispatcher/module to stop waiting

### DIFF
--- a/kqml/cl_json.py
+++ b/kqml/cl_json.py
@@ -23,7 +23,8 @@ class CLJsonConverter(object):
         elif isinstance(json_obj, bytes):
             json_obj = json.loads(json_obj.decode('utf-8'))
         elif not isinstance(json_obj, list) and not isinstance(json_obj, dict):
-            raise ValueError("Input must be list, dict, or string/bytes json.")
+            raise ValueError("Input must be list, dict, or string/bytes "
+                             "json, got %s." % type(json_obj))
         return self._cl_from_json(json_obj)
 
     def _cl_from_json(self, json_obj):
@@ -64,7 +65,8 @@ class CLJsonConverter(object):
         returned as None, even if the value was intended, or originally, False.
         """
         if not isinstance(kqml_list, KQMLList):
-            raise ValueError("Only a KQMLList might be converted into json.")
+            raise ValueError("Only a KQMLList might be converted into json, "
+                             "got %s." % type(kqml_list))
         return self._cl_to_json(kqml_list)
 
     def _cl_to_json(self, kqml_thing):

--- a/kqml/kqml_dispatcher.py
+++ b/kqml/kqml_dispatcher.py
@@ -1,4 +1,7 @@
 import logging
+from .kqml_exceptions import StopWaitingSignal
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,8 +22,10 @@ class KQMLDispatcher(object):
             while True:
                 msg = self.reader.read_performative()
                 self.dispatch_message(msg)
-        # FIXME: not handling KQMLException and
-        # KQMLBadCharacterException
+        # This signal allows the dispatcher to stop blocking and return without
+        # closing the connection to the socket and exiting
+        except StopWaitingSignal:
+            return
         except KeyboardInterrupt:
             logger.info('Keyboard interrupt received')
             self.receiver.receive_eof()

--- a/kqml/kqml_dispatcher.py
+++ b/kqml/kqml_dispatcher.py
@@ -1,5 +1,5 @@
 import logging
-logger = logging.getLogger('KQMLDispatcher')
+logger = logging.getLogger(__name__)
 
 
 class KQMLDispatcher(object):
@@ -34,9 +34,6 @@ class KQMLDispatcher(object):
             logger.error('Value error during reading')
             logger.exception(e)
             return
-
-    def warn(self, msg):
-        logger.warning(msg)
 
     def shutdown(self):
         self.shutdown_initiated = True

--- a/kqml/kqml_exceptions.py
+++ b/kqml/kqml_exceptions.py
@@ -1,30 +1,38 @@
 class KQMLException(Exception):
     pass
 
+
 class KQMLBadCharacterException(KQMLException):
     pass
+
 
 class KQMLBadCloseException(KQMLException):
     pass
 
+
 class KQMLBadCommaException(KQMLException):
     pass
+
 
 class KQMLBadHashException(KQMLException):
     pass
 
+
 class KQMLBadOpenException(KQMLException):
     pass
+
 
 class KQMLBadPerformativeException(KQMLException):
     pass
 
+
 class KQMLBadCommandException(KQMLException):
     pass
+
 
 class KQMLExpectedListException(KQMLException):
     pass
 
+
 class KQMLExpectedWhitespaceException(KQMLException):
     pass
-

--- a/kqml/kqml_exceptions.py
+++ b/kqml/kqml_exceptions.py
@@ -36,3 +36,7 @@ class KQMLExpectedListException(KQMLException):
 
 class KQMLExpectedWhitespaceException(KQMLException):
     pass
+
+
+class StopWaitingSignal(KQMLException):
+    pass

--- a/kqml/kqml_list.py
+++ b/kqml/kqml_list.py
@@ -5,6 +5,7 @@ from .kqml_string import KQMLString
 import kqml.kqml_reader as kqml_reader
 from .util import safe_decode, safe_encode
 
+
 class KQMLList(KQMLObject):
     def __init__(self, objects=None):
         self.data = []
@@ -95,7 +96,6 @@ class KQMLList(KQMLObject):
         if param is not None:
             return safe_decode(param.string_value())
         return None
-
 
     def append(self, obj):
         """Append an element to the end of the list.

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -5,7 +5,7 @@ import socket
 import logging
 from kqml import KQMLReader, KQMLDispatcher
 from kqml import KQMLList, KQMLPerformative
-from .kqml_exceptions import KQMLException
+from .kqml_exceptions import KQMLException, StopWaitingSignal
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +202,9 @@ class KQMLModule(object):
             if self.dispatcher is not None:
                 self.dispatcher.shutdown()
             sys.exit(n)
+
+    def stop_waiting(self):
+        raise StopWaitingSignal()
 
     def receive_eof(self):
         self.exit(0)

--- a/kqml/kqml_module.py
+++ b/kqml/kqml_module.py
@@ -7,7 +7,7 @@ from kqml import KQMLReader, KQMLDispatcher
 from kqml import KQMLList, KQMLPerformative
 from .kqml_exceptions import KQMLException
 
-logger = logging.getLogger('KQMLModule')
+logger = logging.getLogger(__name__)
 
 
 # On Windows, sockets need to be created via the msvcrt

--- a/kqml/kqml_quotation.py
+++ b/kqml/kqml_quotation.py
@@ -1,6 +1,7 @@
 from io import StringIO
 from kqml import KQMLObject
 
+
 class KQMLQuotation(KQMLObject):
     def __init__(self, quote_type, kqml_object):
         self.quote_type = quote_type

--- a/kqml/kqml_reader.py
+++ b/kqml/kqml_reader.py
@@ -8,7 +8,8 @@ from .kqml_token import KQMLToken
 from .kqml_string import KQMLString
 from .kqml_quotation import KQMLQuotation
 
-logger = logging.getLogger('KQMLReader')
+logger = logging.getLogger(__name__)
+
 
 class KQMLReader(object):
     def __init__(self, reader):

--- a/kqml/kqml_token.py
+++ b/kqml/kqml_token.py
@@ -2,6 +2,7 @@ import re
 from kqml import KQMLObject
 from .util import safe_decode
 
+
 class KQMLToken(KQMLObject):
     def __init__(self, s=None):
         if s is None:
@@ -47,8 +48,8 @@ class KQMLToken(KQMLObject):
         return self.data.startswith(':')
 
     def parse_package(self):
-        g1 = re.match('([^:]+)::([^:]+)$', self.data)
-        g2 = re.match('([^:]+)::(\|[^\|]*\|)$', self.data)
+        g1 = re.match(r'([^:]+)::([^:]+)$', self.data)
+        g2 = re.match(r'([^:]+)::(\|[^\|]*\|)$', self.data)
         if g1:
             package, bare_name = g1.groups()
         elif g2:


### PR DESCRIPTION
This PR introduces a new method in the KQMLModule which allows signaling to the KQMLDispatcher to stop waiting for incoming messages without otherwise disconnecting from the socket or exiting.